### PR TITLE
Fix broken osx-arm64 cross installation

### DIFF
--- a/.ci_support/linux_64_python3.10.____cpython.yaml
+++ b/.ci_support/linux_64_python3.10.____cpython.yaml
@@ -2,8 +2,6 @@ c_stdlib:
 - sysroot
 c_stdlib_version:
 - '2.17'
-cdt_name:
-- conda
 channel_sources:
 - conda-forge
 channel_targets:

--- a/.ci_support/linux_64_python3.11.____cpython.yaml
+++ b/.ci_support/linux_64_python3.11.____cpython.yaml
@@ -2,8 +2,6 @@ c_stdlib:
 - sysroot
 c_stdlib_version:
 - '2.17'
-cdt_name:
-- conda
 channel_sources:
 - conda-forge
 channel_targets:

--- a/.ci_support/linux_64_python3.12.____cpython.yaml
+++ b/.ci_support/linux_64_python3.12.____cpython.yaml
@@ -2,8 +2,6 @@ c_stdlib:
 - sysroot
 c_stdlib_version:
 - '2.17'
-cdt_name:
-- conda
 channel_sources:
 - conda-forge
 channel_targets:

--- a/.ci_support/linux_64_python3.13.____cp313.yaml
+++ b/.ci_support/linux_64_python3.13.____cp313.yaml
@@ -2,8 +2,6 @@ c_stdlib:
 - sysroot
 c_stdlib_version:
 - '2.17'
-cdt_name:
-- conda
 channel_sources:
 - conda-forge
 channel_targets:

--- a/README.md
+++ b/README.md
@@ -202,12 +202,12 @@ it is possible to build and upload installable packages to the
 [conda-forge](https://anaconda.org/conda-forge) [anaconda.org](https://anaconda.org/)
 channel for Linux, Windows and OSX respectively.
 
-To manage the continuous integration and simplify feedstock maintenance
+To manage the continuous integration and simplify feedstock maintenance,
 [conda-smithy](https://github.com/conda-forge/conda-smithy) has been developed.
 Using the ``conda-forge.yml`` within this repository, it is possible to re-render all of
 this feedstock's supporting files (e.g. the CI configuration files) with ``conda smithy rerender``.
 
-For more information please check the [conda-forge documentation](https://conda-forge.org/docs/).
+For more information, please check the [conda-forge documentation](https://conda-forge.org/docs/).
 
 Terminology
 ===========
@@ -234,7 +234,7 @@ merged, the recipe will be re-built and uploaded automatically to the
 everybody to install and use from the `conda-forge` channel.
 Note that all branches in the conda-forge/grouper-feedstock are
 immediately built and any created packages are uploaded, so PRs should be based
-on branches in forks and branches in the main repository should only be used to
+on branches in forks, and branches in the main repository should only be used to
 build distinct package versions.
 
 In order to produce a uniquely identifiable distribution:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -28,8 +28,6 @@ requirements:
     - pip
     - pybind11
     - nlohmann_json
-    - librdkit-dev
-    - rdkit
     - librdkit <=2024.09.3
     - rdkit
     - librdkit-dev
@@ -38,13 +36,8 @@ requirements:
     - llvm-openmp
   run:
     - python
-    - libboost-python-devel
-    - librdkit
-    - libpq
     - rdkit
     - eigen
-    - pybind11
-    - nauty
     - jupyter
     - seaborn
     - cairosvg
@@ -53,7 +46,6 @@ requirements:
     - dash
     - dash_cytoscape
     - scikit-learn
-    - llvm-openmp
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,11 @@ source:
   sha256: b6fddeb6bad6eb758a86e00ee5091b2f6634221515fef04c0b7c021b9de8a8db
 
 build:
-  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+  script:
+    # CMakeLists.txt uses CONDA_PREFIX and with conda-build
+    # CONDA_PREFIX == BUILD_PREFIX and CONDA_PREFIX != PREFIX
+    - export CONDA_PREFIX=$PREFIX
+    - {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
   number: 2
   skip: true  # [win]
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -28,14 +28,14 @@ requirements:
     - pip
     - pybind11
     - nlohmann_json
-    - librdkit <=2024.09.3
     - rdkit
-    - librdkit-dev
+    - librdkit-dev <=2024.09.3
     - libboost-devel
     - nauty
     - llvm-openmp
   run:
     - python
+    - {{ pin_compatible("librdkit", exact=True) }}
     - rdkit
     - eigen
     - jupyter

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -37,6 +37,7 @@ requirements:
     - libboost-devel
     - nauty
     - llvm-openmp
+    - libpq
   run:
     - python
     - {{ pin_compatible("librdkit", exact=True) }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
 
 build:
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
-  number: 1
+  number: 2
   skip: true  # [win]
 
 requirements:
@@ -22,12 +22,6 @@ requirements:
     - {{ stdlib("c") }}
     - cmake
     - make 
-    - librdkit <=2024.09.3
-    - rdkit
-    - librdkit-dev
-    - libboost-devel
-    - nauty
-    - llvm-openmp
   host:
     - python
     - scikit-build-core
@@ -36,6 +30,12 @@ requirements:
     - nlohmann_json
     - librdkit-dev
     - rdkit
+    - librdkit <=2024.09.3
+    - rdkit
+    - librdkit-dev
+    - libboost-devel
+    - nauty
+    - llvm-openmp
   run:
     - python
     - libboost-python-devel


### PR DESCRIPTION
move librdkit-dev, librdkit, rdkit, libboost-devel, nauty, and llvm-openmp from build to host

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

[Closing #3]
